### PR TITLE
[draft] add: change effects to call supabase

### DIFF
--- a/src/front/app/auth/effects.cljs
+++ b/src/front/app/auth/effects.cljs
@@ -1,0 +1,38 @@
+(ns front.app.auth.effects
+  (:require
+   [front.app.auth.supabase :as supabase]
+   [promesa.core :as p]
+   [refx.alpha :refer [dispatch reg-fx]]))
+
+(defn- js->cljs-key [obj]
+  (js->clj obj :keywordize-keys true))
+
+(defn send-email [{:keys [body on-success on-failure]}]
+  (let [client ^js (supabase/create-client
+                    "https://tgvdfxurgsddxouxmugs.supabase.co"
+                    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRndmRmeHVyZ3NkZHhvdXhtdWdzIiwicm9sZSI6ImFub24iLCJpYXQiOjE2ODE1MDM0NDMsImV4cCI6MTk5NzA3OTQ0M30.7pq4MM_ZldiWvOk_cnQuxlvUF8eFcxlPDB7jMTNMYb0")]
+    (prn :client client)
+    (-> (supabase/signin-with-email client (:email body))
+        (p/then (fn [resp]
+                  (let [obj (js->cljs-key resp)]
+                    (if (:error obj)
+                      (do
+                        (js/console.error :resp-faiure obj)
+                        (dispatch (conj on-failure {:body obj})))
+                      (do
+                        (js/console.log :resp-success obj)
+                        (dispatch (conj on-success {:body (assoc
+                                                           (js->cljs-key resp)
+                                                           :ok true)})))))))
+
+        (p/catch (fn [resp]
+                   (js/console.log :resp resp)
+                   (dispatch (conj on-failure {:body (js->cljs-key resp)})))))))
+
+(defn auth-effect [fn-req]
+  (fn [req]
+    (fn-req req)))
+
+(reg-fx :auth (auth-effect send-email))
+
+

--- a/src/front/app/auth/events.cljs
+++ b/src/front/app/auth/events.cljs
@@ -1,5 +1,6 @@
 (ns front.app.auth.events
-  (:require [front.app.http]
+  (:require #_[front.app.http]
+   [front.app.auth.effects]
             [front.app.auth.db :as auth.db]
             [refx.alpha :as refx]
             [refx.interceptors :refer [after]]))
@@ -17,7 +18,7 @@
  [(after set-current-user-cookie!)]
  (fn
    [{db :db} [_ response]]
-   (println :success response)
+   (prn :success-login response)
    {:db (-> db
             (assoc :login-loading? false)
             (assoc :login-error nil)
@@ -52,7 +53,7 @@
  :app.auth/send-email-done
  (fn
    [{db :db} [_ response]]
-   (println :success response)
+   (prn :success-email response)
    {:db (-> db
             (assoc :login-loading? false)
             (assoc :login-error nil)
@@ -62,26 +63,23 @@
  :app.auth/send-email-error
  (fn
    [db [key-error val-error]]
-   (js/console.error key-error val-error)
+   (js/console.error :error-email key-error val-error)
+   (prn :error-email key-error val-error)
    (-> db
        (assoc :login-loading? false)
-       (assoc :login-error [key-error (:body val-error)])
+       (assoc :login-error [key-error (-> val-error :body :error)])
        (assoc :login-email-sent nil))))
 
 (refx/reg-event-fx
  :app.auth/send-email
  (fn
    [{db :db} [_ login]]
-   {:http {:method      :post
-           :url         "/login/send-email"
-           :body        login
-           :accept :json
-           :content-type :json
-           :on-success  [:app.auth/send-email-done]
+   {:auth {:body login
+           :on-success [:app.auth/send-email-done]
            :on-failure  [:app.auth/send-email-error]}
-    :db  (assoc db
-                :login-error nil
-                :login-loading? true)}))
+    :db (assoc db
+               :login-error nil
+               :login-loading? true)}))
 
 (refx/reg-event-db
  :app.auth/send-email-again

--- a/src/front/app/auth/supabase.cljs
+++ b/src/front/app/auth/supabase.cljs
@@ -1,15 +1,29 @@
 (ns front.app.auth.supabase
-  (:require ["@supabase/supabase-js" :as sb]
-            [promesa.core :as p]))
+  (:require ["@supabase/supabase-js" :as sb]))
 
-(def auth (sb/createClient
-           "https://tgvdfxurgsddxouxmugs.supabase.co"
-           "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRndmRmeHVyZ3NkZHhvdXhtdWdzIiwicm9sZSI6ImFub24iLCJpYXQiOjE2ODE1MDM0NDMsImV4cCI6MTk5NzA3OTQ0M30.7pq4MM_ZldiWvOk_cnQuxlvUF8eFcxlPDB7jMTNMYb0"))
+(defn create-client
+  "creates a supabase client"
+  ([url key]
+   (.createClient sb url key))
+  ([url key options]
+   (.createClient sb url key options)))
 
-(defn signin-with-email
-  [email]
-  ;; (prn :send-magic (.signIn
-  ;;                   auth
-  ;;                   email
-  ;;                   #js {:redirectTo "http://127.0.0.1:8000/#/lerolero"}))
+(defn signin-with-email [^js client email]
+  (prn :signin-with-email email)
+  (let [auth (.-auth client)
+        promise (.signInWithOtp auth #js {:email email})]
+    promise))
+
+(comment
+  ; auth supabase with client side using email
+  (def client
+    (create-client
+     "https://tgvdfxurgsddxouxmugs.supabase.co"
+     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRndmRmeHVyZ3NkZHhvdXhtdWdzIiwicm9sZSI6ImFub24iLCJpYXQiOjE2ODE1MDM0NDMsImV4cCI6MTk5NzA3OTQ0M30.7pq4MM_ZldiWvOk_cnQuxlvUF8eFcxlPDB7jMTNMYb0"))
+
+  (prn :client client)
+  (signin-with-email client "matheusmachadoufsc@gmail.com")
+
+  ;
   )
+

--- a/src/front/app/auth/views.cljs
+++ b/src/front/app/auth/views.cljs
@@ -144,10 +144,10 @@
      [query-params]
      (if-let [error-msg (:error_description query-params)]
        (refx/dispatch [:app.auth/error error-msg])
-       (refx/dispatch [:app.auth/login (select-keys query-params [:code])])))
+       (refx/dispatch [:app.auth/login (select-keys query-params [:access_token])])))
 
     ($ AuthLayout
        (when loading?
          (d/div
           ;; todo better screen for this
-          (str "Validating... " (:code query-params)))))))
+          (str "Validating... " (:access_token query-params)))))))

--- a/src/front/app/http.cljs
+++ b/src/front/app/http.cljs
@@ -32,6 +32,7 @@
                                               :body "Response not set in mocks!"})]
       (p/delay (or lag 100) response))))
 
+
 (reg-fx :http (http-effect fetch/request))
 
 (comment


### PR DESCRIPTION
- [ ] needs to fix all test
- [ ] needs to change the login/auth call to set token
- [ ] it will be necessary mock effects on test
- [ ] needs to change the redirect URL from supabase


when clicking on magic-link on supabase it will redirect to baseurl:8000/access_token=.... so we need to change it, but also  we just need to set the token on your localstorage, this effect https://github.com/cljazz/moclojer-app/blob/supabase/src/front/app/auth/events.cljs#L41 do not need to call a backend auth anymore, just need to go to success and set it the token on browser local storage