### PR TITLE
Testes de falha do cloud-ops restantes

### DIFF
--- a/test/back/back/integration/cloud_ops/fail_create_domain_test.clj
+++ b/test/back/back/integration/cloud_ops/fail_create_domain_test.clj
@@ -1,0 +1,54 @@
+(ns back.integration.cloud-ops.fail-create-domain-test
+  (:require [back.integration.components.utils :as utils]
+            [cloud-ops.api.ports.workers :as workers]
+            [com.stuartsierra.component :as component]
+            [components.config :as config]
+            [components.http :as http]
+            [components.redis-publisher :as redis-publisher]
+            [muuntaja.core :as m]
+            [state-flow.api :as sf]))
+
+(def mocked-provider-data
+  (atom {:cf {:result []}
+         :do {:app {:spec {:domains []}}}}))
+
+(def mocked-responses
+  [{:url "https://api.cloudflare.com/client/v4/zones/c6f10cf4dd7ace4b979d60c22066be23/dns_records"
+    :method :get
+    :response
+    (fn [_]
+      {:status 200
+       :body (slurp (m/encode "application/json" (:cf @mocked-provider-data)))})}
+   {:url "https://api.digitalocean.com/v2/apps/4dd19675-0b62-4b9a-8082-8ee5d9eab99a"
+    :method :get
+    :response
+    (fn [_]
+      {:status 200
+       :body (slurp (m/encode "application/json" (:do @mocked-provider-data)))})}
+   {:url "https://api.cloudflare.com/client/v4/zones/c6f10cf4dd7ace4b979d60c22066be23/dns_records"
+    :method :post
+    :response {:status 500}}])
+
+(defn- create-and-start-components! []
+  (component/system-map
+   :config (config/new-config)
+   :http (http/new-http-mock mocked-responses)
+   :publisher (component/using
+               (redis-publisher/mock-redis-publisher)
+               [:config])))
+
+(sf/defflow
+  flow-fail-create-domain
+  {:init (utils/start-system! create-and-start-components!)
+   :cleanup utils/stop-system!
+   :fail-fast? true}
+  (sf/flow
+    "should fail to create cloudflare record"
+    [components (sf/get-state)
+     err-url (sf/invoke #(try
+                           (workers/create-domain-handler
+                            {:event {:domain "test-j0suetm"}} components)
+                           (catch Throwable e
+                             (-> e ex-data :req :url))))]
+    (sf/match? "https://api.cloudflare.com/client/v4/zones/c6f10cf4dd7ace4b979d60c22066be23/dns_records"
+               err-url)))

--- a/test/back/back/integration/cloud_ops/fail_retrieve_data_test.clj
+++ b/test/back/back/integration/cloud_ops/fail_retrieve_data_test.clj
@@ -1,0 +1,38 @@
+(ns back.integration.cloud-ops.fail-retrieve-data-test
+  (:require [back.integration.components.utils :as utils]
+            [cloud-ops.api.ports.workers :as workers]
+            [com.stuartsierra.component :as component]
+            [components.config :as config]
+            [components.http :as http]
+            [components.redis-publisher :as redis-publisher]
+            [state-flow.api :as sf]))
+
+(def mocked-responses
+  [{:url "https://api.cloudflare.com/client/v4/zones/c6f10cf4dd7ace4b979d60c22066be23/dns_records"
+    :method :get
+    :response {:status 500
+               :body ""}}])
+
+(defn- create-and-start-components! []
+  (component/system-map
+   :config (config/new-config)
+   :http (http/new-http-mock mocked-responses)
+   :publisher (component/using
+               (redis-publisher/mock-redis-publisher)
+               [:config])))
+
+(sf/defflow
+  flow-fail-retrieve-data
+  {:init (utils/start-system! create-and-start-components!)
+   :cleanup utils/stop-system!
+   :fail-fast? true}
+  (sf/flow
+    "should fail to retrieve current cloudflare records"
+    [components (sf/get-state)
+     err-url (sf/invoke #(try
+                           (workers/create-domain-handler
+                            {:event {:domain "test-j0suetm"}} components)
+                           (catch Throwable e
+                             (-> e ex-data :req :url))))]
+    (sf/match? "https://api.cloudflare.com/client/v4/zones/c6f10cf4dd7ace4b979d60c22066be23/dns_records"
+               err-url)))


### PR DESCRIPTION
fixes #295 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added critical request handling with exception throwing for unexpected response statuses in the `HttpProvider` protocol.
	- Introduced `request-or-throw` function in the `HttpProvider` protocol implementation in `Http` record and `new-http` function.

- **Tests**
	- Added `fail_create_domain_test.clj` file with mocked responses for Cloudflare and DigitalOcean API calls, including a test case for failing to create a Cloudflare record.
	- Added `fail_retrieve_data_test.clj` file with a test scenario for a failed data retrieval request from Cloudflare using mocked responses and system components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->